### PR TITLE
Bump to Rust 1.93 for nearcore 2.12

### DIFF
--- a/.github/workflows/on-release-publish.yml
+++ b/.github/workflows/on-release-publish.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           # latest_version=$(echo "${{ steps.get_rust_version_string_from_toml.outputs.result }}" |  cut -d' ' -f1)
           # latest_version=${latest_version#v}  # Remove 'v' prefix if exists
-          latest_version=1.86.0
+          latest_version=1.93.0
           echo "latest_version=$latest_version" >> $GITHUB_ENV
           echo "latest_version=$latest_version"
           echo "latest_version=$latest_version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
2.12 (protocol 84) moves the contract toolchain to 1.93, so this bumps the image's rust version up to match. cargo-near 0.20.3 keys off near-sdk's min_protocol_version, so anything still on older near-sdk keeps resolving to the 1.86 image through its own build metadata. Built and tested it locally, rustc 1.93 and cargo-near 0.20.3 are in the image and a protocol-84 contract builds clean.
