### PR TITLE
fix: make commit image Rust version explicit

### DIFF
--- a/.github/workflows/cargo-near-commit-publish.yml
+++ b/.github/workflows/cargo-near-commit-publish.yml
@@ -6,6 +6,9 @@ on:
       CARGO_NEAR_COMMIT:
         description: 'Commit hash for cargo-near'
         required: true
+      RUST_VERSION:
+        description: 'Rust version for the build image, without a v prefix, for example 1.93.0'
+        required: true
 
 jobs:
   build_and_push:
@@ -16,14 +19,20 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Get latest Rust version
-        id: get_rust_version
+      - name: Validate inputs
+        env:
+          CARGO_NEAR_COMMIT: ${{ inputs.CARGO_NEAR_COMMIT }}
+          RUST_VERSION: ${{ inputs.RUST_VERSION }}
         run: |
-          latest_version=$(curl -s https://api.github.com/repos/rust-lang/rust/releases/latest | jq -r '.tag_name')
-          latest_version=${latest_version#v}  # Remove 'v' prefix if exists
-          echo "latest_version=$latest_version" >> $GITHUB_ENV
-          echo "latest_version=$latest_version"
-          echo "latest_version=$latest_version" >> $GITHUB_OUTPUT
+          if ! printf '%s' "$CARGO_NEAR_COMMIT" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+            echo "CARGO_NEAR_COMMIT must be a full 40-character commit SHA"
+            exit 1
+          fi
+
+          if ! printf '%s' "$RUST_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "RUST_VERSION must be a full Rust version like 1.93.0"
+            exit 1
+          fi
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -37,7 +46,7 @@ jobs:
         with:
           images: ${{ secrets.DOCKER_HUB_REPO }}
           tags: |
-            type=raw,value=git-${{ github.event.inputs.CARGO_NEAR_COMMIT }}-${{ steps.get_rust_version.outputs.latest_version }}
+            type=raw,value=git-${{ inputs.CARGO_NEAR_COMMIT }}-${{ inputs.RUST_VERSION }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -46,7 +55,7 @@ jobs:
           file: ./cargo-near-commit/Dockerfile
           push: true
           build-args: |
-            RUST_VERSION=${{ steps.get_rust_version.outputs.latest_version }}
-            CARGO_NEAR_COMMIT=${{ github.event.inputs.CARGO_NEAR_COMMIT }}
+            RUST_VERSION=${{ inputs.RUST_VERSION }}
+            CARGO_NEAR_COMMIT=${{ inputs.CARGO_NEAR_COMMIT }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- add a required RUST_VERSION input to the cargo-near commit image publish workflow
- remove the automatic latest Rust release lookup
- use the manual Rust version for the Docker tag and build args

Fixes #5

## Checks
- git diff --check
- YAML parse